### PR TITLE
Initial Commit

### DIFF
--- a/UnloadPlugins.mac
+++ b/UnloadPlugins.mac
@@ -1,0 +1,12 @@
+Sub Main
+	/declare i int local 0
+	/for i 1 to 100
+		/if (${Plugin[${i}].Name.Length}) {
+			/if (${Plugin[${i}].Name.Equal[mq2ic]}) /continue
+			/if (${Plugin[${i}].Name.Equal[mq2chatwnd]}) /continue
+			/if (${Plugin[${i}].Name.Equal[mq2eqbugfix]}) /continue
+			/if (${Plugin[${i}].Name.Equal[mq2map]}) /continue
+			/plugin ${Plugin[${i}].Name} unload noauto
+		}
+	/next i
+/return


### PR DESCRIPTION
Quickly unload nearly every plugin for debugging purposes. Uses the noauto param so that it doesn't stay unloaded between sessions, so loading them back up should be as simple as reinjecting. Useful when experiencing crashes so that you can reload plugins one at a time till the crash occurs again.